### PR TITLE
Culled the 64c rans_static and added new code for 4x8 and 4x16 variants (the old 4k and 4_16i files).

### DIFF
--- a/makefile
+++ b/makefile
@@ -227,8 +227,7 @@ OB+=pithy/pithy.o
 OB+=shoco/shoco.o
 OB+=shrinker/Shrinker.o
 OB+=wflz/wfLZ.o 
-OB+=xpack/lib/xpack_common.o xpack/lib/xpack_compress.o xpack/lib/xpack_decompress.o
-# xpack/lib/x86_cpu_features.o
+OB+=xpack/lib/xpack_common.o xpack/lib/xpack_compress.o xpack/lib/xpack_decompress.o xpack/lib/x86_cpu_features.o
 OB+=yappy/yappy.o 
 ifeq ($(NCPP), 0)
 OB+=CSC/src/libcsc/csc_analyzer.o CSC/src/libcsc/csc_coder.o CSC/src/libcsc/csc_dec.o CSC/src/libcsc/csc_default_alloc.o CSC/src/libcsc/csc_enc.o CSC/src/libcsc/csc_encoder_main.o CSC/src/libcsc/csc_filters.o CSC/src/libcsc/csc_lz.o CSC/src/libcsc/csc_memio.o \
@@ -300,7 +299,7 @@ endif
 #-------------------- Entropy Coder -------------------
 ifeq ($(NECODER), 0)
 OB+=FastARI/FastAri.o 
-OB+=rans_static_/rANS_static4_16i.o rans_static_/arith_static.o
+OB+=rans_static/rANS_static4x8.o rans_static/rANS_static4x16.o rans_static/rANS_static.o rans_static_/arith_static.o
 #OB+=ans_jb/rANS_static4c.o ans_jb/arith_static.o rans_static_/rANS_static4c.o rans_static_/rANS_static4k.o 
 OB+=zlibh/zlibh.o
 OB+=subotin_/subotin.o 

--- a/plugins.cc
+++ b/plugins.cc
@@ -207,8 +207,8 @@ enum {
 #define C_JRANS		ECODER 
  P_JRANS4_16o0,
  P_JRANS4_16o1,
- P_JRANS64o0,
- P_JRANS64o1,
+ P_JRANS4_8o0,
+ P_JRANS4_8o1,
 
 #define C_FPAQC 	GPL
  P_FPAQC,
@@ -619,10 +619,7 @@ struct snappy_env env;
   #endif
   
   #if C_JRANS
-#include "rans_static_/rANS_static.h"
-    #ifdef __x86_64__
-#include "rans_static_/rANS_static64c.h"
-    #endif	
+#include "rans_static/rANS_static.h"
   #endif
 
   #if C_FPAQC
@@ -759,11 +756,10 @@ struct plugs plugs[] = {
   { P_FQZ0, 	"fqz0",				C_FQZ, 		"15-03",	"FQZ/PPMD Range Coder",	"Public Domain",	"http://encode.ru/threads/2149-ao0ec-Bytewise-adaptive-order-0-entropy-coder",			""},
   { P_PPMDEC, 	"ppmdec", 			C_PPMDEC,	"15-03",	"PPMD Range Coder",		"Public Domain",	"http://encode.ru/threads/2149-ao0ec-Bytewise-adaptive-order-0-entropy-coder",  		""},
 
-  { P_JRANS4_16o0,"rans_static",    C_JRANS,	"16-06",	"ANS/J.Bonfield",		"Public Domain",	"https://github.com/jkbonfield/rans_static",											"", E_ANS},
-  { P_JRANS4_16o1,"rans_static_o1", C_JRANS,    "16-06",	"ANS/J.Bonfield",		"Public Domain",	"https://github.com/jkbonfield/rans_static",											"", E_ANS},
-  { P_JRANS64o0, "rans_static64",	C_JRANS, 	"15-08",	"ANS 64/J.Bonfield",	"Public Domain",	"https://github.com/jkbonfield/rans_static",											"", E_ANS},
-  { P_JRANS64o1, "rans_static64_o1",C_JRANS, 	"15-08",	"ANS 64/J.Bonfield",	"Public Domain",	"https://github.com/jkbonfield/rans_static",											"", E_ANS},
-  
+  { P_JRANS4_16o0,"rans_static_4x16",    C_JRANS,	"16-06",	"ANS/J.Bonfield",		"Public Domain",	"https://github.com/jkbonfield/rans_static",											"", E_ANS},
+  { P_JRANS4_16o1,"rans_static_4x16_o1", C_JRANS,    "16-06",	"ANS/J.Bonfield",		"Public Domain",	"https://github.com/jkbonfield/rans_static",											"", E_ANS},
+  { P_JRANS4_8o0,"rans_static_4x8",    C_JRANS,	"16-06",	"ANS/J.Bonfield",		"Public Domain",	"https://github.com/jkbonfield/rans_static",											"", E_ANS},
+  { P_JRANS4_8o1,"rans_static_4x8_o1", C_JRANS,    "16-06",	"ANS/J.Bonfield",		"Public Domain",	"https://github.com/jkbonfield/rans_static",											"", E_ANS},
   { P_NANS,	    "naniarans",		C_NANS, 	"2015",	    "Nania Adaptive rANS",	"           ",		"http://encode.ru/threads/2079-nARANS-(Nania-Adaptive-Range-Variant-of-ANS)",			"", E_ANS},
   { P_POLHF,    "polar", 			C_POLHF, 	"10-07",	"Polar Codes",			"GPL license",		"http://www.ezcodesample.com/prefixer/prefixer_article.html",							"" },
   { P_SUB, 		"subotin", 			C_SUBOTIN, 	"2000",		"subotin RC",			"Public Domain",	"http://ezcodesample.com/ralpha/Subbotin.txt",											"" },
@@ -1302,11 +1298,11 @@ int codcomp(unsigned char *in, int inlen, unsigned char *out, int outsize, int c
       #endif
 
 	  #if C_JRANS
-    case P_JRANS4_16o0: { unsigned int outlen = outsize; return rans_compress_to(in, inlen, out, &outlen,0) ? outlen : 0;}
-    case P_JRANS4_16o1: { unsigned int outlen = outsize; return rans_compress_to(in, inlen, out, &outlen,1) ? outlen : 0;} 
+    case P_JRANS4_16o0: { unsigned int outlen = outsize; return rans_compress_to(16, in, inlen, out, &outlen,0) ? outlen : 0;}
+    case P_JRANS4_16o1: { unsigned int outlen = outsize; return rans_compress_to(16, in, inlen, out, &outlen,1) ? outlen : 0;} 
+    case P_JRANS4_8o0: { unsigned int outlen = outsize; return rans_compress_to(8, in, inlen, out, &outlen,0) ? outlen : 0;}
+    case P_JRANS4_8o1: { unsigned int outlen = outsize; return rans_compress_to(8, in, inlen, out, &outlen,1) ? outlen : 0;} 
          #ifdef __x86_64__
-    case P_JRANS64o0:  return rans64_compress_O0(in, inlen, out, oend);
-    case P_JRANS64o1:  return rans64_compress_O1(in, inlen, out, oend);
         #endif
 	  #endif
 
@@ -1684,12 +1680,10 @@ int coddecomp(unsigned char *in, int inlen, unsigned char *out, int outlen, int 
       #endif
 
 	  #if C_JRANS
-    case P_JRANS4_16o0: rans_uncompress_to(in, inlen, out, &outlen,0); break;
-    case P_JRANS4_16o1: rans_uncompress_to(in, inlen, out, &outlen,1); break;
-        #ifdef __x86_64__
-    case P_JRANS64o0:   rans64_uncompress_O0(in, inlen, out, outlen); break;
-    case P_JRANS64o1:   rans64_uncompress_O1(in, inlen, out, outlen); break; 	
-        #endif
+    case P_JRANS4_16o0: rans_uncompress_to(16, in, inlen, out, &outlen,0); break;
+    case P_JRANS4_16o1: rans_uncompress_to(16, in, inlen, out, &outlen,1); break;
+    case P_JRANS4_8o0: rans_uncompress_to(8, in, inlen, out, &outlen,0); break;
+    case P_JRANS4_8o1: rans_uncompress_to(8, in, inlen, out, &outlen,1); break;
 	  #endif
 
       #if C_FPAQC


### PR DESCRIPTION
This is using rans_static as a submodule now, but note the arith_static is still using the old copy rather than the submodule as I haven't gone through fixing the API for this yet.

I'd suggest adding 4x16 and 4x16_o1 into the default list of -eENTROPY and ignoring the others.
