### PR TITLE
Update BriefLZ to 1.2.0

### DIFF
--- a/makefile
+++ b/makefile
@@ -156,8 +156,8 @@ endif
  
 #------------- 
 # 
-CFLAGS+=$(DDEBUG) -w -std=gnu99 -fpermissive -Wall -Izstd/lib -Izstd/lib/common $(DEFS) -Ilz4/lib -Ilizard/lib -Ibrotli/c/include -Ibrotli/c/enc -Ilibdeflate -Ilibdeflate/common -Ifastbase64/include -Ibrieflz/include
-CXXFLAGS+=$(DDEBUG) -w -fpermissive -Wall -fno-rtti -Ilzham_codec_devel/include -Ilzham_codec_devel/lzhamcomp -Ilzham_codec_devel/lzhamdecomp -D"UINT64_MAX=-1ull" -Ibrotli/c/include -Ibrotli/c/enc -ICSC/src/libcsc -D_7Z_TYPES_ -DLIBBSC_SORT_TRANSFORM_SUPPORT $(DEFS)
+CFLAGS+=$(DDEBUG) -std=gnu99 -Wall -Izstd/lib -Izstd/lib/common $(DEFS) -Ilz4/lib -Ilizard/lib -Ibrotli/c/include -Ibrotli/c/enc -Ilibdeflate -Ilibdeflate/common -Ifastbase64/include -Ibrieflz/include
+CXXFLAGS+=$(DDEBUG) -fpermissive -Wall -fno-rtti -Ilzham_codec_devel/include -Ilzham_codec_devel/lzhamcomp -Ilzham_codec_devel/lzhamdecomp -D"UINT64_MAX=-1ull" -Ibrotli/c/include -Ibrotli/c/enc -ICSC/src/libcsc -D_7Z_TYPES_ -DLIBBSC_SORT_TRANSFORM_SUPPORT $(DEFS)
 
 all:  turbobench
 

--- a/makefile
+++ b/makefile
@@ -156,7 +156,7 @@ endif
  
 #------------- 
 # 
-CFLAGS+=$(DDEBUG) -w -std=gnu99 -fpermissive -Wall -Izstd/lib -Izstd/lib/common $(DEFS) -Ilz4/lib -Ilizard/lib -Ibrotli/c/include -Ibrotli/c/enc -Ilibdeflate -Ilibdeflate/common -Ifastbase64/include
+CFLAGS+=$(DDEBUG) -w -std=gnu99 -fpermissive -Wall -Izstd/lib -Izstd/lib/common $(DEFS) -Ilz4/lib -Ilizard/lib -Ibrotli/c/include -Ibrotli/c/enc -Ilibdeflate -Ilibdeflate/common -Ifastbase64/include -Ibrieflz/include
 CXXFLAGS+=$(DDEBUG) -w -fpermissive -Wall -fno-rtti -Ilzham_codec_devel/include -Ilzham_codec_devel/lzhamcomp -Ilzham_codec_devel/lzhamdecomp -D"UINT64_MAX=-1ull" -Ibrotli/c/include -Ibrotli/c/enc -ICSC/src/libcsc -D_7Z_TYPES_ -DLIBBSC_SORT_TRANSFORM_SUPPORT $(DEFS)
 
 all:  turbobench
@@ -310,7 +310,7 @@ endif
 DIVSUFSORT=libbsc/libbsc/bwt/divsufsort/divsufsort.o
 OB+=balz/balz.o
 OB+=bcm_/bcm.o
-OB+=brieflz/brieflz.o brieflz/depack.o
+OB+=brieflz/src/brieflz.o brieflz/src/depack.o
 OB+=chameleon/chameleon.o
 OB+=crush/crush.o
 OB+=libbsc/libbsc/libbsc/libbsc.o libbsc/libbsc/coder/coder.o libbsc/libbsc/coder/qlfc/qlfc.o libbsc/libbsc/coder/qlfc/qlfc_model.o libbsc/libbsc/platform/platform.o libbsc/libbsc/filters/detectors.o \

--- a/plugins.cc
+++ b/plugins.cc
@@ -997,7 +997,7 @@ NOINLINE void libmemcpy(unsigned char *dst, unsigned char *src, int len) {
 }
 
 static int dicsize;
-int coddicsize(int _dicsize) { dicsize = _dicsize; }	
+void coddicsize(int _dicsize) { dicsize = _dicsize; }
 
 static char _workmem[1<<16],*workmem=_workmem;
 static int state_size,dstate_size;
@@ -1088,6 +1088,7 @@ int codini(size_t insize, int codec, int lev) {
     fprintf(stderr, "Malloc error: %d\n", workmemsize); 
     exit(0);
   }
+  return 1;
 }  
 
 void codexit(int codec) { 
@@ -1661,6 +1662,7 @@ int codcomp(unsigned char *in, int inlen, unsigned char *out, int outsize, int c
  
     defaulf: fprintf(stderr, "library '%d' not included\n", codec);
   } 
+  return 0;
 } 
   
 int coddecomp(unsigned char *in, int inlen, unsigned char *out, int outlen, int codec, int lev, char *prm) {	
@@ -2139,6 +2141,7 @@ int coddecomp(unsigned char *in, int inlen, unsigned char *out, int outlen, int 
 //   case P_MYCODEC:   return mydecomp(in, inlen, out, outlen);
 	  #endif	
   }
+  return 0;
 }
 
 char *codver(int codec, char *v, char *s) {

--- a/plugins.cc
+++ b/plugins.cc
@@ -362,7 +362,7 @@ enum {
   #endif
   
   #if C_BRIEFLZ 
-#include "brieflz/brieflz.h"
+#include "brieflz/include/brieflz.h"
   #endif
   
   #if C_LIBBSC
@@ -840,7 +840,7 @@ struct plugs plugs[] = {
   { P_BALZ, 	"balz", 			C_BALZ, 	"1.20",		"balz",					"Public Domain",	"http://sourceforge.net/projects/balz", 												"0,1" }, 
   { P_BCM, 		"bcm", 				C_BCM, 		"1.25",		"bcm",					"Public Domain",	"https://github.com/encode84/bcm", 													"" }, 
   { P_C_BLOSC2, "blosc",			C_C_BLOSC2, "2.0",		"Blosc",				"BSD license",		"https://github.com/Blosc/c-blosc2", 													"0,1,2,3,4,5,6,7,8,9", 64*1024},
-  { P_BRIEFLZ,	"brieflz", 		    C_BRIEFLZ, 	"1.1.0",	"BriefLz",				"BSD like",			"https://github.com/jibsen/brieflz", 													"" }, 
+  { P_BRIEFLZ,	"brieflz", 		    C_BRIEFLZ, 	"1.2.0",	"BriefLz",				"BSD like",			"https://github.com/jibsen/brieflz", 													"1,3,6,9" }, 
   { P_BROTLI,	"brotli", 			C_BROTLI, 	"17-04",	"Brotli",				"Apache license",	"https://github.com/google/brotli", 													"0,1,2,3,4,5,6,7,8,9,10,11/d#:V"},
   { P_BZIP2,	"bzip2", 			C_BZIP2, 	"1.06",		"Bzip2",				"BSD like",			"http://www.bzip.org/downloads.html\thttps://github.com/asimonov-im/bzip2", 			"" }, 
   { P_CHAMELEON,"chameleon",		C_CHAMELEON, "15-03",	"Chameleon",			"Public Domain",	"http://cbloomrants.blogspot.de/2015/03/03-25-15-my-chameleon.html", 					"1,2" },
@@ -1003,7 +1003,7 @@ static char _workmem[1<<16],*workmem=_workmem;
 static int state_size,dstate_size;
 static size_t workmemsize;
 
-int codini(size_t insize, int codec) {
+int codini(size_t insize, int codec, int lev) {
   workmemsize = 0;
 
   switch(codec) {
@@ -1052,7 +1052,7 @@ int codini(size_t insize, int codec) {
       #endif
  
       #if C_BRIEFLZ
-    case P_BRIEFLZ: workmemsize = blz_workmem_size(insize); break;
+    case P_BRIEFLZ: workmemsize = blz_workmem_size_level(insize, lev); break;
       #endif  
 
       #if C_SNAPPY_C
@@ -1127,7 +1127,7 @@ int codcomp(unsigned char *in, int inlen, unsigned char *out, int outsize, int c
       #endif 
 
       #if C_BRIEFLZ
-	case P_BRIEFLZ: return blz_pack(in, out, inlen, workmem);
+	case P_BRIEFLZ: return blz_pack_level(in, out, inlen, workmem, lev);
 	  #endif
 	  
       #if C_BROTLI

--- a/plugins.h
+++ b/plugins.h
@@ -38,7 +38,7 @@ extern "C" {
   #endif
 extern struct plugs plugs[];
 int coddicsize(int _dicsize);
-int  codini(size_t insize, int codec);
+int  codini(size_t insize, int codec, int lev);
 void codexit(int codec);
 int  codstart( unsigned char *in, int inlen, int codec);
 int  codcomp(  unsigned char *in, int inlen, unsigned char *out, int outsize, int codec, int lev, char *prm);

--- a/plugins.h
+++ b/plugins.h
@@ -37,7 +37,7 @@ struct plugs {
 extern "C" {
   #endif
 extern struct plugs plugs[];
-int coddicsize(int _dicsize);
+void coddicsize(int _dicsize);
 int  codini(size_t insize, int codec, int lev);
 void codexit(int codec);
 int  codstart( unsigned char *in, int inlen, int codec);

--- a/turbobench.c
+++ b/turbobench.c
@@ -932,6 +932,7 @@ int plugprts(struct plug *plug, int k, char *finame, int xstdout, unsigned long 
   }
   plugprtf(fo, fmt);
   fclose(fo);
+  return 1;
 } 
 
 int plugread(struct plug *plug, char *finame, long long *totinlen) {

--- a/turbobench.c
+++ b/turbobench.c
@@ -1100,7 +1100,7 @@ unsigned long long plugfile(struct plug *plug, char *finame, unsigned long long 
   if((cmp || tid) && insizem && !(_cpy = _valloc(insizem,3)))
     die("malloc error cpy size=%u\n", insizem);
  
-  codini(insize, plug->id);	
+  codini(insize, plug->id, plug->lev);	
   size_t    inlen;																	
   long long totinlen = 0;
   double    ptc = DBL_MAX, ptd = DBL_MAX;


### PR DESCRIPTION
This updates the BriefLZ plugin to 1.2.0.

Also fixes an interesting error with non-void functions not returning anything. This is undefined behavior, and it turned out GCC used that to produce buggy code. The makefile used `-w` which disabled any warnings about it. Specifically, the test for `workmemsize` at the end of `codini()` always resulted in an error no matter what the size was.

A little example (just because it's so absurd):

~~~cpp
#include <stdio.h>
#include <stdlib.h>

int foo(int argc) {
  if (argc > 4) {
    printf("In C++, %d > 4 .. wat?", argc);
    exit(0);
  }
}

int main(int argc, char *argv[]) {
  foo(argc);
}
~~~

~~~sh
$ g++ -w -O3 wat.cpp
$ ./a.out
In C++, 1 > 4 .. wat?
~~~
