### PR TITLE
zxc: fix build and use persistent contexts

### DIFF
--- a/makefile
+++ b/makefile
@@ -848,7 +848,6 @@ else
 ifeq ($(ZXC),1)
 CXXFLAGS+=-D_ZXC -DZXC_STATIC_DEFINE
 CFLAGS+=-Izxc/src/lib/vendors -DZXC_STATIC_DEFINE
-OB+= $(ZXCDIR)/zxc_common.o $(ZXCDIR)/zxc_driver.o $(ZXCDIR)/zxc_dispatch.o $(ZXCDIR)/zxc_compress_default.o $(ZXCDIR)/zxc_decompress_default.o
 
 #from lzbench 
 ZXCDIR = zxc/src/lib

--- a/plugin.cc
+++ b/plugin.cc
@@ -1337,6 +1337,10 @@ static ZSTD_DDict *ddictPtr;
 static char _workmem[1<<16],*workmem=_workmem;
 static int state_size,dstate_size;
 static size_t workmemsize;
+#if _ZXC
+static zxc_cctx *zxc_cctx_ptr = NULL;
+static zxc_dctx *zxc_dctx_ptr = NULL;
+#endif
 
 int codini(size_t insize, int codec, int lev, char *prm) {
   workmemsize = 0;
@@ -1487,6 +1491,13 @@ int codini(size_t insize, int codec, int lev, char *prm) {
 //    case P_FSEH: workmemsize = max(4096*sizeof(unsigned), workmemsize); break;
       #endif
 
+      #if _ZXC
+    case P_ZXC:
+      zxc_cctx_ptr = zxc_create_cctx(NULL);
+      zxc_dctx_ptr = zxc_create_dctx();
+      break;
+      #endif
+
       #ifdef _LZTURBO
     #include "../dev/x/beplug0.h"
       #endif
@@ -1538,6 +1549,12 @@ void codexit(int codec) {
     #if _SNAPPY_C
   if(codec == P_SNAPPY_C)
     snappy_free_env(&env);
+    #endif
+    #if _ZXC
+  if(codec == P_ZXC) {
+    zxc_free_cctx(zxc_cctx_ptr); zxc_cctx_ptr = NULL;
+    zxc_free_dctx(zxc_dctx_ptr); zxc_dctx_ptr = NULL;
+  }
     #endif
 }
 
@@ -2080,8 +2097,7 @@ unsigned codcomp(unsigned char *in, unsigned inlen, unsigned char *out, unsigned
 	  #if _ZXC
     case P_ZXC: {
 	  zxc_compress_opts_t opts = {.n_threads = 1, .level = lev, .checksum_enabled = 0};
-	  return zxc_compress(in, inlen, out, outsize, &opts);
-	  
+	  return zxc_compress_cctx(zxc_cctx_ptr, in, inlen, out, outsize, &opts);
     }
       #endif
 
@@ -2846,7 +2862,7 @@ unsigned coddecomp(unsigned char *in, unsigned inlen, unsigned char *out, unsign
 	  #if _ZXC
     case P_ZXC: {
 	  zxc_decompress_opts_t opts = {.n_threads = 1, .checksum_enabled = 0};
-	  zxc_decompress(in, inlen, out, outlen, &opts);
+	  zxc_decompress_dctx(zxc_dctx_ptr, in, inlen, out, outlen, &opts);
 	  break;
     }
       #endif


### PR DESCRIPTION
This PR contains two small improvements to the zxc integration.

## 1. Fix redundant object file definitions

The `ZXC=1` branch in the makefile appended the zxc object list twice: once before `ZXCDIR` was defined (producing paths like `/zxc_common.o`) and once after with the correct prefix. The first list was a no-op at best and caused link-time warnings at worst. This commit removes the stray first list and keeps a single, correct `OB +=` using `$(ZXCDIR)`.

## 2. Use persistent zxc contexts via codini/codexit

zxc exposes reusable encoder/decoder contexts (`zxc_cctx` / `zxc_dctx`) precisely for high-frequency call sites where per-call allocation overhead matters: which is exactly TurboBench's profile. Previously the plugin allocated and freed context state inside every `codcomp` / `coddecomp` call via the one-shot buffer API.

This commit follows the existing TurboBench pattern used by lzfse, lzo and others: contexts are created once in `codini()` and released in `codexit()`, then reused across iterations.

## Results (Silesia corpus, Apple M3, single-threaded)

The final `SCORE` values are unchanged (both branches hit the same best-of-N peak), but the first-iteration throughput and iteration-to-iteration stability both improve noticeably. For example, at level 5 compression:

|              | iter 1  | iter 2  | iter 3  | best    |
|--------------|---------|---------|---------|---------|
| before       | 110.95  | 112.96  | 115.54  | 118.81  |
| after        | 118.71  | 118.71  | 118.71  | 118.81  |

This matters for realistic single-shot workloads (e.g. decompressing assets at app startup), which is zxc's primary use case.
