### PR TITLE
Add PivCo-Huffman codec

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -88,3 +88,6 @@
 [submodule "lzav"]
 	path = lzav
 	url = https://github.com/avaneev/lzav.git
+[submodule "pivco-huffman"]
+	path = pivco-huffman
+	url = https://github.com/MarcinZukowski/pivco-huffman

--- a/makefile
+++ b/makefile
@@ -977,6 +977,25 @@ $(PIVCOHUFDIR)/build/libpivco_huffman_local.o:
 OB+=$(PIVCOHUFDIR)/build/libpivco_huffman_local.o
 endif
 
+# PHAZ: PivCo-Huffman entropy transplant onto zstd (full LZ+entropy compressor;
+# level = zstd level).  Built from the pivco-huffman submodule's extras/phaz via
+# its own build.sh: it patches a *private* copy of zstd source (pointed at
+# TurboBench's own zstd/ submodule, same pinned SHA 5233c58e) and merges it +
+# pivco into one blob (phaz_local.o) that exports only phaz_compress /
+# phaz_decompress -- everything else (all of zstd, FSE/HUF, pivco) is localized,
+# so it coexists with the vanilla zstd TurboBench links.  Requires:
+#   git submodule update --init --recursive pivco-huffman zstd
+ifeq ($(PHAZ), 1)
+PIVCOHUFDIR=pivco-huffman
+PHAZDIR=$(PIVCOHUFDIR)/extras/phaz
+CXXFLAGS+=-D_PHAZ=1
+$(PHAZDIR)/build/phaz_local.o:
+	cmake -S $(PIVCOHUFDIR) -B $(PIVCOHUFDIR)/build -DCMAKE_BUILD_TYPE=Release
+	cmake --build $(PIVCOHUFDIR)/build --target pivco_huffman_local -j
+	ZSTD_SRC=$(abspath zstd) MARCH="$(MARCH)" CC=$(CC) bash $(PHAZDIR)/tools/build.sh
+OB+=$(PHAZDIR)/build/phaz_local.o
+endif
+
 #--------------------------------------------------------------------
 CFLAGS+=$(DDEBUG) -w -std=gnu99 -fpermissive -Wall
 CXXFLAGS+=$(DDEBUG) -w -fpermissive -Wall -fno-rtti

--- a/makefile
+++ b/makefile
@@ -962,6 +962,21 @@ CXXFLAGS+=-D_PYSAP
 OB+=pysap/pysapcompress/vpa105CsObjInt.o pysap/pysapcompress/vpa106cslzc.o pysap/pysapcompress/vpa107cslzh.o pysap/pysapcompress/vpa108csulzh.o
 endif
 
+# PivCo-Huffman (https://github.com/MarcinZukowski/pivco-huffman): SIMD tree-walk
+# Huffman, levels 1=PH, 2=PHA.  Submodule built via its own CMake; we link the
+# pre-localized object (libpivco_huffman_local.o) whose vendored FSE_*/HUF_*
+# symbols are localized so they don't clash with the zstd TurboBench bundles.
+# The submodule has its own submodule (ext/fse), so init recursively:
+#   git submodule update --init --recursive pivco-huffman
+ifeq ($(PIVCOHUF), 1)
+PIVCOHUFDIR=pivco-huffman
+CXXFLAGS+=-D_PIVCOHUF=1 -I$(PIVCOHUFDIR)/include
+$(PIVCOHUFDIR)/build/libpivco_huffman_local.o:
+	cmake -S $(PIVCOHUFDIR) -B $(PIVCOHUFDIR)/build -DCMAKE_BUILD_TYPE=Release
+	cmake --build $(PIVCOHUFDIR)/build --target pivco_huffman_local -j
+OB+=$(PIVCOHUFDIR)/build/libpivco_huffman_local.o
+endif
+
 #--------------------------------------------------------------------
 CFLAGS+=$(DDEBUG) -w -std=gnu99 -fpermissive -Wall
 CXXFLAGS+=$(DDEBUG) -w -fpermissive -Wall -fno-rtti

--- a/plugin.cc
+++ b/plugin.cc
@@ -434,6 +434,10 @@ enum {
 #define _XPACK 0
 #endif
  P_XPACK,
+#ifndef _PIVCOHUF
+#define _PIVCOHUF 0
+#endif
+ P_PIVCOHUF,          // PivCo-Huffman (ph/pha)
  P_MYCODEC, // User plugin
   #ifdef _LZTURBO
 #include "../dev/x/beplug.h"
@@ -1084,6 +1088,10 @@ const MarlinDictionary * Marlin_estimate_best_dictionary(const MarlinDictionary 
 //#include "my_header.h"
   #endif
 
+  #if _PIVCOHUF
+#include "pivcohuf_file.h"
+  #endif
+
   #if __cplusplus
 extern "C" {
   #endif
@@ -1255,6 +1263,7 @@ struct plugs plugs[] = {
   { P_MARLIN,       "Marlin",      _MARLIN,    "Marlin Entropy coder",    ""},
   { P_NIBRANS,      "nibrans",     _NIBRANS,   "nibrans",                 ""},
   { P_OODLE,        "oodle",        _OODLE,     "Oodle 8:Kraken 9:Mermaid 11:Selkie 12:Hydra 13:Leviathan", "01,02,03,04,05,06,07,08,09,11,12,13,14,15,16,17,18,19,21,22,23,24,25,26,27,28,29,41,42,43,44,45,46,47,48,49,51,52,53,54,55,56,57,58,59,61,62,63,64,65,66,67,68,69,71,72,73,74,75,76,77,78,79,81,82,83,84,85,86,87,88,89,-81,-82,-83,91,92,93,94,95,96,97,98,99,-91,-92,-93,101,102,103,104,105,106,107,108,109,111,112,113,114,115,116,117,118,119,-111,-112,-113,121,122,123,124,125,126,127,128,129,131,132,133,134,135,136,137,138,139" },
+  { P_PIVCOHUF,     "ph",          _PIVCOHUF,  "PivCo-Huffman",           "1,2" },  // 1=PH, 2=PHA (ANS-gated bitmaps)
   { P_POLHF,        "polar",       _POLHF,     "Polar Codes",             "" },
   { P_PPMDEC,       "ppmdec",      _PPMDEC,    "PPMD Range Coder",        ""},
 
@@ -2412,6 +2421,11 @@ unsigned codcomp(unsigned char *in, unsigned inlen, unsigned char *out, unsigned
     #include "../dev/x/beplugc.c"
       #endif
 
+      #if _PIVCOHUF
+    case P_PIVCOHUF: { size_t ol = outsize;   /* lev 1=PH, 2=PHA */
+                 if(pivcohuf_compress_ex(in, inlen, out, &ol, lev>=2) != PIVCOHUF_OK) return 0;
+                 return (unsigned)ol; }
+      #endif
       #if _MYCODEC
 //    case P_MYCODEC:   return mycomp(in, inlen, out, outsize);
       #endif
@@ -3154,6 +3168,11 @@ unsigned coddecomp(unsigned char *in, unsigned inlen, unsigned char *out, unsign
     #include "../dev/x/beplugd.c"
       #endif
 
+      #if _PIVCOHUF
+    case P_PIVCOHUF: { size_t ol = outlen;
+                 if(pivcohuf_decompress(in, inlen, out, &ol) != PIVCOHUF_OK) return 0;
+                 return (unsigned)ol; }
+      #endif
       #if _MYCODEC
 //   case P_MYCODEC:   return mydecomp(in, inlen, out, outlen);
       #endif

--- a/plugin.cc
+++ b/plugin.cc
@@ -438,6 +438,10 @@ enum {
 #define _PIVCOHUF 0
 #endif
  P_PIVCOHUF,          // PivCo-Huffman (ph/pha)
+#ifndef _PHAZ
+#define _PHAZ 0
+#endif
+ P_PHAZ,              // PHAZ: PivCo-Huffman entropy transplant onto zstd
  P_MYCODEC, // User plugin
   #ifdef _LZTURBO
 #include "../dev/x/beplug.h"
@@ -1092,6 +1096,13 @@ const MarlinDictionary * Marlin_estimate_best_dictionary(const MarlinDictionary 
 #include "pivcohuf_file.h"
   #endif
 
+  #if _PHAZ
+// phaz_local.o exports only these (zstd + pivco localized inside the blob).
+// Last arg is a phaz_stats* (passed 0 here); declared void* to avoid the header.
+extern "C" size_t phaz_compress(const void *src, size_t n, void *dst, size_t cap, int level, void *st);
+extern "C" size_t phaz_decompress(const void *src, size_t n, void *dst, size_t cap, void *st);
+  #endif
+
   #if __cplusplus
 extern "C" {
   #endif
@@ -1215,6 +1226,7 @@ struct plugs plugs[] = {
   { P_MINIZ,      "miniz",       _MINIZ,     "miniz zlib-replace",      "1,2,3,4,5,6,7,8,9" },
   { P_MSCOMPRESS, "mscompress",  _MSCOMPRESS,"ms-compress",             "2,3,4" },
   { P_NAKA,       "naka",        _NAKA,      "Nakamichi Washigan",      "" },
+  { P_PHAZ,       "phaz",        _PHAZ,      "PivCo-Huffman/zstd",      "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22" },  // level = zstd level
   { P_PITHY,      "pithy",       _PITHY,     "Pithy",                   "0,1,2,3,4,5,6,7,8,9" },
   { P_QUICKLZ,    "quicklz",     _QUICKLZ,   "Quicklz",                 "1,2,3" },
   { P_QCOMPRESS32,"qcomp32",     _QCOMPRESS, "quantile compression",    "1,2,3,4,5,6,7,8,9" },
@@ -2426,6 +2438,9 @@ unsigned codcomp(unsigned char *in, unsigned inlen, unsigned char *out, unsigned
                  if(pivcohuf_compress_ex(in, inlen, out, &ol, lev>=2) != PIVCOHUF_OK) return 0;
                  return (unsigned)ol; }
       #endif
+      #if _PHAZ
+    case P_PHAZ: return (unsigned)phaz_compress(in, inlen, out, outsize, lev, 0);  /* lev = zstd level */
+      #endif
       #if _MYCODEC
 //    case P_MYCODEC:   return mycomp(in, inlen, out, outsize);
       #endif
@@ -3172,6 +3187,9 @@ unsigned coddecomp(unsigned char *in, unsigned inlen, unsigned char *out, unsign
     case P_PIVCOHUF: { size_t ol = outlen;
                  if(pivcohuf_decompress(in, inlen, out, &ol) != PIVCOHUF_OK) return 0;
                  return (unsigned)ol; }
+      #endif
+      #if _PHAZ
+    case P_PHAZ: return (unsigned)phaz_decompress(in, inlen, out, outlen, 0);
       #endif
       #if _MYCODEC
 //   case P_MYCODEC:   return mydecomp(in, inlen, out, outlen);


### PR DESCRIPTION
This PR adds two codecs from the PivCo-Huffman project (https://github.com/MarcinZukowski/pivco-huffman), both off by default and built from a single pivco-huffman submodule:
* ph — PivCo-Huffman, a SIMD tree-walk Huffman codec with a flat-subtree fast path. Two levels: 1 = PH (plain), 2 = PHA (per-node FSE/ANS-coded partition bitmaps for a better ratio on skewed data). An entropy-only coder.
* phaz — PivCo-Huffman entropy transplant onto zstd, a full compressor: it keeps zstd's LZ parse + copy engine and replaces only the entropy layer (FSE sequence codes + literal Huffman) with PivCo-Huffman/PHA over the pivoted ll/ml/of/lit streams. Directly comparable to zstd; level = zstd level. On silesia/dickens it decodes 1.6–2.1× faster than zstd at matched ratio (phaz-3 3192 vs zstd-3 1517 MB/s; phaz-19 3057 vs zstd-19 1931).

Wired in like the other library codecs:
- submodule: pivco-huffman added once (recursive — it carries its own ext/fse submodule for the FSE entropy coder PHA needs). phaz lives inside it at extras/phaz, so it needs no separate submodule.
- ph (`PIVCOHUF=1`): builds the submodule via its own CMake and links libpivco_huffman_local.o — that object has the vendored `FSE_*/HUF_*` symbols localized so they don't clash with the zstd TurboBench already bundles. plugin.cc dispatches P_PIVCOHUF via pivcohuf_compress_ex / pivcohuf_decompress.
- phaz (`PHAZ=1`): builds `extras/phaz` in the submodule via its own build.sh, which patches a private copy of zstd (pointed at TurboBench's own zstd/ submodule, same pinned SHA) and merges it + pivco into one phaz_local.o exporting only phaz_compress/phaz_decompress — everything else (all of zstd, FSE/HUF, pivco) is localized, so it coexists with the vanilla zstd TurboBench links. plugin.cc dispatches P_PHAZ via those two entry points.

Off by default. Enable after `git submodule update --init --recursive pivco-huffman zstd`:

    make PIVCOHUF=1     # ph
    make PHAZ=1         # phaz

The two codecs are separate commits, so they can be split if you'd prefer to take them one at a time.