### PR TITLE
misa77: build with -O3, update to v0.2.0, map compression levels

### DIFF
--- a/makefile
+++ b/makefile
@@ -535,7 +535,7 @@ CXXFLAGS+=-D_MISA77
 MISA77_DIR = misa77
 MISA77_INC = -I$(MISA77_DIR)/include -I$(MISA77_DIR)/src
 
-CMD_BUILD_MISA77 = $(CXX) $(CXXFLAGS) -std=c++20 $(MISA77_INC) $(MISA77_FLAGS) $< -c -o $@
+CMD_BUILD_MISA77 = $(CXX) -O3 $(CXXFLAGS) -std=c++20 $(MISA77_INC) $(MISA77_FLAGS) $< -c -o $@
 misa77/%_avx2.o: CXXFLAGS+=-mavx2
 misa77/%_avx2.o: misa77/%.cpp ; $(CMD_BUILD_MISA77)
 misa77/%_sse2.o: CXXFLAGS+=-msse2

--- a/plugin.cc
+++ b/plugin.cc
@@ -1974,12 +1974,11 @@ unsigned codcomp(unsigned char *in, unsigned inlen, unsigned char *out, unsigned
       #endif
 
       #if _MISA77
-    case P_MISA77: 
+    case P_MISA77:
       switch (lev) {
-        case 0: 
-        case 1:  return misa77::experimental::adaptive_compress(in, inlen, out, outsize, lev); 
-        case 3:  return misa77::experimental::yolo_compress(in, inlen, out, outsize); 
-        default: return misa77::compress(in, inlen, out, outsize);                          
+        case 2:
+        case 3:  return misa77::experimental::adaptive_compress(in, inlen, out, outsize, lev - 2);
+        default: return misa77::compress(in, inlen, out, outsize, misa77::config(lev));
       }
       #endif
 


### PR DESCRIPTION
Thanks for adding misa77 to TurboBench! I'm the misa77 author. This PR fixes an optimization-flag issue in the misa77 build rule, updates the submodule to v0.2.0, and maps the levels to the new API.

## Build fix: misa77 was compiled without optimization

TurboBench's generic rules carry `-O3` in the recipe (`.cpp.o: $(CXX) -O3 $(MARCH) $(CXXFLAGS) ...`), not in `CXXFLAGS`, so the custom `CMD_BUILD_MISA77` rule was building all misa77 units at `-O0`. This cost about 3.5× on decompression and 6× on compression.

## Version bump + level mapping

misa77 v0.2.0 adds compression levels to the main codec. Level string `0,1,2,3` is unchanged:

- `0,1` map to `misa77::compress(..., config(level))`, the library's real levels: 0 = faster decompression, 1 = better ratio (the library default)
- `2,3` map to `experimental::adaptive_compress` tiers 0 (loose) / 1 (tight) (previously levels 0,1)
- `yolo_compress` (previously level 3) is superseded by level 0 and no longer mapped

## Results with this branch

silesia.tar, i7-14650HX (@2.2 GHz, P-core pinned, no turbo), `-I5 -J9`:

```
  C Size    ratio%   C MB/s    D MB/s  Name
 77263513    36.5      7.30   2509.21  lz4 12
 84042203    39.7     51.69   4276.53  misa77 1
 90386641    42.6     54.88   5217.42  misa77 0
100882958    47.6    363.83   2518.81  lz4 1
```
