### PR TITLE
misa77: expose level 2, split safe/unsafe codecs, pin ISA fallback flags

### DIFF
--- a/makefile
+++ b/makefile
@@ -352,21 +352,23 @@ ifneq ($(wildcard misa77/.),)
 CXXFLAGS += -D_MISA77
 MISA77_DIR  := misa77
 MISA77_INC  := -I$(MISA77_DIR)/include -I$(MISA77_DIR)/src
-MISA77_SRCS := $(wildcard $(MISA77_DIR)/src/*.cpp $(MISA77_DIR)/src/experimental/*.cpp)
-MISA77_OBJS := $(MISA77_DIR)/src/isa/target_portable.o $(MISA77_DIR)/src/experimental/isa/etarget_portable.o
+MISA77_SRCS := $(wildcard $(MISA77_DIR)/src/*.cpp)
+MISA77_OBJS := $(MISA77_DIR)/src/isa/target_portable.o
 MISA77_BUILD = $(CXX) -O3 $(CXXFLAGS) -std=c++20 $(MISA77_INC) $(MISA77_FLAGS) $< -c -o $@
-$(BUILDIR)/$(MISA77_DIR)/src/%_sse2.o: CXXFLAGS += $(_SSE)
-$(BUILDIR)/$(MISA77_DIR)/src/%_avx2.o: CXXFLAGS += $(_AVX2)
+ifeq ($(ARCH),x86_64)
+MISA77_BASE := -march=x86-64
+MISA77_AVX2 := -mavx2
+endif
+$(BUILDIR)/$(MISA77_DIR)/src/%_portable.o: CXXFLAGS += $(MISA77_BASE)
+$(BUILDIR)/$(MISA77_DIR)/src/%_sse2.o: CXXFLAGS += $(MISA77_BASE)
+$(BUILDIR)/$(MISA77_DIR)/src/%_avx2.o: CXXFLAGS += $(MISA77_AVX2)
 
 $(BUILDIR)/$(MISA77_DIR)/src/%.o: $(MISA77_DIR)/src/%.cpp
 	@mkdir -p $(dir $@)
 	$(MISA77_BUILD)
-$(BUILDIR)/$(MISA77_DIR)/src/experimental/isa/%.o: $(MISA77_DIR)/src/experimental/%.cpp
-	@mkdir -p $(dir $@)
-	$(MISA77_BUILD)
 
 OB += $(call obj,$(MISA77_SRCS) $(MISA77_OBJS))
-MISA77_ARCH_OBJS.x86_64  := isa/target_sse2.o isa/target_avx2.o experimental/isa/etarget_sse2.o experimental/isa/etarget_avx2.o
+MISA77_ARCH_OBJS.x86_64  := isa/target_sse2.o isa/target_avx2.o
 MISA77_ARCH_OBJS.aarch64 := isa/target_neon.o
 OB += $(addprefix $(BUILDIR)/$(MISA77_DIR)/src/,$(MISA77_ARCH_OBJS.$(ARCH)))
 endif

--- a/plugin.cc
+++ b/plugin.cc
@@ -215,7 +215,7 @@ enum {
 #define _MISA77 0
 #endif
  P_MISA77,
- P_MISA77U,
+ P_MISA77S,
 #ifndef _MSCOMPRESS
 #define _MSCOMPRESS 0
 #endif
@@ -869,7 +869,6 @@ class Out: public libzpaq::Writer {
 
   #if _MISA77
 #include "misa77/include/misa77/misa77.h"
-#include "misa77/include/misa77/experimental.h"
   #endif
 
   #if _MSCOMPRESS
@@ -1633,8 +1632,8 @@ struct plugs plugs[] = {
 
   { P_MEMLZ,         "memlz",         _MEMLZ,     "memlz",                   "" },
   { P_MINIZ,         "miniz",         _MINIZ,     "miniz",                   "1,2,3,4,5,6,7,8,9" },
-  { P_MISA77,        "misa77",        _MISA77,    "misa77",                  "0,1,2,3" },
-  { P_MISA77U,       "misa77u",       _MISA77,    "misa77 unsafe",           "0,1,2,3" },
+  { P_MISA77,        "misa77",        _MISA77,    "misa77",                  "0,1,2" },
+  { P_MISA77S,       "misa77_safe",   _MISA77,    "misa77 safe",             "0,1" },
   { P_MSCOMPRESS,    "mscompress",    _MSCOMPRESS,"ms-compress",             "2,3,4" },
  
   { P_NAKA,          "naka",          _NAKA,      "Nakamichi Washigan",      "" },
@@ -2439,12 +2438,7 @@ unsigned codcomp(unsigned char *in, unsigned inlen, unsigned char *out, unsigned
 
       #if _MISA77
     case P_MISA77:
-    case P_MISA77U: 
-      switch (lev) {
-        case 2:
-        case 3:  return misa77::experimental::adaptive_compress(in, inlen, out, outsize, lev - 2);
-        default: return misa77::compress(in, inlen, out, outsize, misa77::config(lev));
-      }
+    case P_MISA77S: return misa77::compress(in, inlen, out, outsize, misa77::config(lev));
       #endif
 
       #if _NAKA
@@ -3299,8 +3293,8 @@ unsigned coddecomp(unsigned char *in, unsigned inlen, unsigned char *out, unsign
       #endif
 
       #if _MISA77
-    case P_MISA77:  return misa77::decompress(in, inlen, out, outlen, misa77::dconfig(true)); 
-    case P_MISA77U: return misa77::decompress(in, inlen, out, outlen); 
+    case P_MISA77:  return misa77::decompress(in, inlen, out, outlen);
+    case P_MISA77S: return misa77::decompress(in, inlen, out, outlen, misa77::dconfig(true));
       #endif
       
       #if _NAKA
@@ -3928,8 +3922,8 @@ char *codver(int codec, char *v, char *s) {
       #endif
 
       #if _MISA77
-    case P_MISA77:     
-    case P_MISA77U:    sprintf(s,"v%d.%d.%d", MISA77_VERSION_MAJOR, MISA77_VERSION_MINOR, MISA77_VERSION_PATCH); break;
+    case P_MISA77:
+    case P_MISA77S:    sprintf(s,"v%d.%d.%d", MISA77_VERSION_MAJOR, MISA77_VERSION_MINOR, MISA77_VERSION_PATCH); break;
       #endif
 
       #if _OPENZL

--- a/turbobench.ini
+++ b/turbobench.ini
@@ -1,5 +1,5 @@
-TURBO     lzturbo,10,11,12,19,20,21,22,29/lz4,1/lizard,10/chameleon,1,2/zxc,3,4,5/misa77,0,1,2,3/memcpy
-FAST      lzturbo,10,10a,11,12,20,20a,21,22,30,30a,31,32/zlib,1,6,9/libdeflate,1,6,9/brotli,0,1,4,5/lz4,1,5,9/lzav/zstd,1,5,9/zxc,3,4,5,7/misa77,0,1,2,3/memcpy
+TURBO     lzturbo,10,11,12,19,20,21,22,29/lz4,1/lizard,10/chameleon,1,2/zxc,3,4,5/misa77,0,1,2/memcpy
+FAST      lzturbo,10,10a,11,12,20,20a,21,22,30,30a,31,32/zlib,1,6,9/libdeflate,1,6,9/brotli,0,1,4,5/lz4,1,5,9/lzav/zstd,1,5,9/zxc,3,4,5,7/misa77,0,1,2/memcpy
 EFFICIENT lzturbo,21,22,30,30a,31,32/brotli,4,5/zlib,5,6/zstd,5,9/zling,4/memcpy							
 MAX       lzturbo,19,29,39,49/lzma,9/lzham,4/brotli,11/lz4,9/lizard,19,29,39,49/lzlib,9/libdeflate,12/zstd,22/memcpy
 OPTIMAL   lzturbo,19,29,39,49/lzma,9/lzham,4/brotli,11/lz4,9/libdeflate,12/lizard,49/lzlib,19,29,39,49/zstd,22/zopfli/memcpy


### PR DESCRIPTION
The level mapping was outdated, so TurboBench was not benchmarking what
v0.5.0 changed. This fixes that, plus two smaller issues.

**Level 2 was unreachable.** The mapping dates from the v0.2.0 integration (my
PR #54), when misa77 had only levels 0 and 1. Levels 2 and 3 were wired to the
experimental adaptive compressor, which emits the light format, so the shipped
level 2 (the heavy format, rewritten in v0.5.0) was never reached. It is now
exposed as level 2, and the experimental compressor is dropped. Ratio improves
by 3-7 points on Silesia over what the old levels 2/3 measured.

**Safe/unsafe polarity.** `misa77` was the safe decoder and `misa77u` the
unsafe one, but unsafe is the library default and what misa77's published
numbers describe. These are swapped, and the safe variant is renamed
`misa77_safe` to match lzbench. It is registered for levels 0,1 only: misa77
has no safe decoder for the heavy format yet, and safe mode returns 0 for
level-2 streams by design.

**SSE2 fallback was built with AVX.** `$(_SSE)` is `-mavx -mpopcnt` on x86_64,
so misa77's SSE2 TU came out VEX-encoded. That TU is selected at runtime
precisely when AVX2 is absent, so a pre-AVX x86_64 CPU would fault in it. The
per-ISA TUs are now pinned as misa77's own CMake pins them: `-march=x86-64`
for the portable and SSE2 fallbacks, `-mavx2` for the AVX2 TU. Both variables
are empty off x86_64, so the aarch64 NEON path is unchanged.